### PR TITLE
Minor fix to quickstart docs

### DIFF
--- a/src/basic/projects.rst
+++ b/src/basic/projects.rst
@@ -33,4 +33,12 @@ They can be created using the ``create_experiment`` command as:
 
    kitedb create_experiment PROJECT_NAME EXPERIMENT_NAME
 
+If this is your first time running kitedb you will need to initialize the database
+
+.. code-block:: bash
+
+   kitedb makemigrations base jobs calcs mols structs workflow
+   kitedb migrate
+
+
 With this, a new experiment titled ``EXPERIMENT_NAME`` will be created under the project ``PROJECT_NAME``.

--- a/src/basic/quickstart.rst
+++ b/src/basic/quickstart.rst
@@ -181,7 +181,7 @@ The job does not have to be executed from the command line. If you prefer to run
    inputs = [{"smiles": "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"}]
    options = {"force_field": "mmff"}
 
-   # because we are going to specify the recipe, we do not
+   # because we are using the recipe, we do not
    # have to specify it.
    info = JobInfo(
         job={},
@@ -224,7 +224,6 @@ We can create different folders for each of the jobs and run them in parallel:
 
     import os
     from mkite_core.models import JobInfo
-    from mkite_conformer.recipes.rdkit import ConformerGenerationRecipe
 
     molecules = {
         "benzene": "c1ccccc1",
@@ -247,6 +246,7 @@ We can create different folders for each of the jobs and run them in parallel:
         info = JobInfo(
             job={},
             recipe={},
+            recipe={"name": "conformer.generation"},
             inputs=get_inputs(smiles),
             options=options,
         )

--- a/src/basic/recipes.rst
+++ b/src/basic/recipes.rst
@@ -2,7 +2,7 @@
 Executing recipes with mkite
 ============================
 
-Recipe in mkite were illustrated in the :doc:`15-min quickstart <quickstart>` guide. 
+Recipes in mkite were illustrated in the :doc:`15-min quickstart <quickstart>` guide. 
 The conformer generation, just like any other recipe, takes a certain number of inputs and optional parameters and returns new results.
 Any recipe works by converting the inputs into new outputs, be it in the form of property (CalcNodes) or new structures (ChemNode).
 For example, a structure relaxation using DFT takes a single input and computes a new, relaxed structure (ChemNode) and the energy (CalcNode) of the relaxed structure (or a series of (structure, energy, forces), if a whole trajectory is stored).


### PR DESCRIPTION
Made a guess to the intention of the example python script when many bash files were created. There doesn't seem to be an easy way to create a json from a recipe, so I removed the import and explicitly stated the recipe. (the json files created from the original version do not work as they have no recipe specified) 